### PR TITLE
Fix memory leak

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,11 @@
  */
 let callbacks = [];
 
-const channel = new MessageChannel();
+let channel = new MessageChannel();
+
+let postMessage = (function() {
+  this.postMessage(undefined);
+}).bind(channel.port2);
 
 // Flush the callback queue when a message is posted to the message channel
 channel.port1.onmessage = () => {
@@ -22,9 +26,8 @@ channel.port1.onmessage = () => {
   }
 };
 
-function postMessage() {
-  channel.port2.postMessage(undefined);
-}
+// If the onmessage handler closes over the MessageChannel, the MessageChannel never gets GC'd:
+channel = null;
 
 /**
  * Invoke the given callback after the browser renders the next frame


### PR DESCRIPTION
MessageChannel has problematic retention semantics and can become a zombie object long after pages are unloaded.
This happens when an `onmessage` handler for a MessageChannel closes over a reference to the MessageChannel instance or its ports, causing a loop that the garbage collector is unable to determine has been broken.